### PR TITLE
Update fr_qwertz.xml

### DIFF
--- a/swissLanguagePack/src/main/res/xml/fr_qwertz.xml
+++ b/swissLanguagePack/src/main/res/xml/fr_qwertz.xml
@@ -8,15 +8,15 @@
     <Row android:keyWidth="9.089994%p">
         <Key android:codes="113" android:popupCharacters="1" android:keyEdgeFlags="left" android:keyLabel="q" />
         <Key android:codes="119" android:popupCharacters="2" android:keyLabel="w"/>
-        <Key android:codes="101" android:popupCharacters="3éè" android:keyLabel="e" />
+        <Key android:codes="101" android:popupCharacters="3éèê€" android:keyLabel="e" />
         <Key android:codes="114" android:popupCharacters="4" android:keyLabel="r" />
         <Key android:codes="116" android:popupCharacters="5" android:keyLabel="t" />
         <Key android:codes="122" android:popupCharacters="6" android:keyLabel="z" />
         <Key android:codes="117" android:popupCharacters="7" android:keyLabel="u" />
         <Key android:codes="105" android:popupCharacters="8" android:keyLabel="i" />
-        <Key android:codes="111" android:popupCharacters="9" android:keyLabel="o" />
+        <Key android:codes="111" android:popupCharacters="9ô" android:keyLabel="o" />
         <Key android:codes="112" android:popupCharacters="0" android:keyLabel="p" />
-        <Key android:codes="232" android:popupCharacters="âü" android:keyEdgeFlags="right" android:keyLabel="è" />
+        <Key android:codes="232" android:popupCharacters="âàûü" android:keyEdgeFlags="right" android:keyLabel="è" />
     </Row>
     <Row android:keyWidth="9.089994%p">
         <Key android:codes="97" android:popupCharacters="!" android:keyEdgeFlags="left" android:keyLabel="a" />


### PR DESCRIPTION
Hello, I don't know anything about AnySoftKeyboard maintenance and extension but as a thankful French-speaking user of your Swiss keyboard pack, I wanted to improve and fix the Swiss-French variant by adding some letters.

I don't know (yet) how to add missing accents on letters that are on rows not visible in this XML file, so this is just a first incomplete proposal.

For example, the "ç" character would be missing as android:popupCharacter for android:keylabel ="c".

Please don't hesitate to contact me, this is a first attempt to contact you with some initial proposal to help improve the Swiss-French keyboard, I am willing to give it a more complete shot.

And thank you for already making a Swiss-French keyboard available, even incomplete.